### PR TITLE
Add PixiJS GSAP footage maker scaffold

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,0 +1,16 @@
+{
+  "name": "pixijs-data-driven",
+  "version": "1.0.0",
+  "description": "Data-driven footage maker using PixiJS and GSAP",
+  "scripts": {
+    "dev": "vite",
+    "build": "vite build"
+  },
+  "dependencies": {
+    "pixi.js": "^7.2.4",
+    "gsap": "^3.12.2"
+  },
+  "devDependencies": {
+    "vite": "^5.2.0"
+  }
+}

--- a/readme.md
+++ b/readme.md
@@ -1,1 +1,25 @@
-Test
+# PixiJS Data-Driven Footage Maker
+
+This project demonstrates a modular architecture for creating animations using **PixiJS** and **GSAP**. Scenes are generated from JSON templates so new effects and layers can be added with minimal code changes.
+
+## Directory Structure
+
+```
+src/
+  core/            # application and scene management
+  effects/         # reusable animation effects
+  templates/       # JSON templates describing scenes
+  utils/           # helper functions for property and animation parsing
+  main.js          # entry file used by Vite
+```
+
+## Development
+
+Install dependencies and start the dev server:
+
+```bash
+npm install
+npm run dev
+```
+
+This serves the project using Vite.

--- a/src/core/AppManager.js
+++ b/src/core/AppManager.js
@@ -1,0 +1,17 @@
+import * as PIXI from 'pixi.js';
+import SceneManager from './SceneManager.js';
+
+export default class AppManager {
+  constructor(options) {
+    this.app = new PIXI.Application(options);
+    this.sceneManager = new SceneManager(this.app);
+  }
+
+  get view() {
+    return this.app.view;
+  }
+
+  loadTemplate(template) {
+    this.sceneManager.loadScene(template);
+  }
+}

--- a/src/core/EffectRegistry.js
+++ b/src/core/EffectRegistry.js
@@ -1,0 +1,7 @@
+export default class EffectRegistry {
+  static effects = {};
+
+  static register(name, handler) {
+    this.effects[name] = handler;
+  }
+}

--- a/src/core/LayerFactory.js
+++ b/src/core/LayerFactory.js
@@ -1,0 +1,21 @@
+import * as PIXI from 'pixi.js';
+import { parseProps } from '../utils/index.js';
+
+export default class LayerFactory {
+  static create(data, app) {
+    let layer;
+    switch (data.type) {
+      case 'text':
+        layer = new PIXI.Text(data.text || '', data.style || {});
+        break;
+      case 'sprite':
+        layer = PIXI.Sprite.from(data.texture);
+        break;
+      default:
+        layer = new PIXI.Container();
+    }
+
+    parseProps(layer, data.props);
+    return layer;
+  }
+}

--- a/src/core/SceneManager.js
+++ b/src/core/SceneManager.js
@@ -1,0 +1,25 @@
+import LayerFactory from './LayerFactory.js';
+import { parseProps, parseAnimations } from '../utils/index.js';
+import EffectRegistry from './EffectRegistry.js';
+
+export default class SceneManager {
+  constructor(app) {
+    this.app = app;
+    this.layers = [];
+  }
+
+  clear() {
+    this.layers.forEach(layer => this.app.stage.removeChild(layer));
+    this.layers = [];
+  }
+
+  loadScene(data) {
+    this.clear();
+    data.layers.forEach(layerData => {
+      const layer = LayerFactory.create(layerData, this.app);
+      this.app.stage.addChild(layer);
+      parseAnimations(layer, layerData.animations, EffectRegistry.effects);
+      this.layers.push(layer);
+    });
+  }
+}

--- a/src/effects/blur.js
+++ b/src/effects/blur.js
@@ -1,0 +1,10 @@
+import { gsap } from 'gsap';
+import { BlurFilter } from 'pixi.js';
+
+export default function blur(target, params = {}, options = {}) {
+  const { strength = 8, duration = 1 } = params;
+  if (!target.filters) target.filters = [];
+  const filter = new BlurFilter(0);
+  target.filters.push(filter);
+  gsap.to(filter, { blur: strength, duration, yoyo: true, repeat: 1, ...options });
+}

--- a/src/effects/bounce.js
+++ b/src/effects/bounce.js
@@ -1,0 +1,11 @@
+import { gsap } from 'gsap';
+
+export default function bounce(target, params = {}, options = {}) {
+  const { from = 0.5, to = 1, duration = 1 } = params;
+  gsap.fromTo(target.scale, { x: from, y: from }, {
+    x: to, y: to,
+    ease: 'elastic.out(1, 0.3)',
+    duration,
+    ...options
+  });
+}

--- a/src/effects/fadeInOut.js
+++ b/src/effects/fadeInOut.js
@@ -1,0 +1,7 @@
+import { gsap } from 'gsap';
+
+export default function fadeInOut(target, params = {}, options = {}) {
+  const { duration = 1 } = params;
+  gsap.fromTo(target, { alpha: 0 }, { alpha: 1, duration: duration / 2, ...options })
+    .to(target, { alpha: 0, duration: duration / 2 });
+}

--- a/src/effects/glitch.js
+++ b/src/effects/glitch.js
@@ -1,0 +1,12 @@
+import { gsap } from 'gsap';
+
+export default function glitch(target, params = {}, options = {}) {
+  const { amount = 5, duration = 0.1, repeat = 20 } = params;
+  gsap.to(target, {
+    pixi: { skewX: () => (Math.random() - 0.5) * amount },
+    repeat,
+    yoyo: true,
+    duration,
+    ...options
+  });
+}

--- a/src/effects/index.js
+++ b/src/effects/index.js
@@ -1,0 +1,13 @@
+import shake from './shake.js';
+import glitch from './glitch.js';
+import blur from './blur.js';
+import bounce from './bounce.js';
+import fadeInOut from './fadeInOut.js';
+
+export default {
+  shake,
+  glitch,
+  blur,
+  bounce,
+  fadeInOut
+};

--- a/src/effects/register.js
+++ b/src/effects/register.js
@@ -1,0 +1,8 @@
+import EffectRegistry from '../core/EffectRegistry.js';
+import effects from './index.js';
+
+export default function registerEffects() {
+  Object.entries(effects).forEach(([name, handler]) => {
+    EffectRegistry.register(name, handler);
+  });
+}

--- a/src/effects/shake.js
+++ b/src/effects/shake.js
@@ -1,0 +1,10 @@
+import { gsap } from 'gsap';
+
+export default function shake(target, params = {}, options = {}) {
+  const { x = 10, y = 10, duration = 0.2, repeat = 5 } = params;
+  gsap.fromTo(target, { x: `-=${x}`, y: `-=${y}` }, {
+    x: `+=${x}`, y: `+=${y}`,
+    duration, repeat, yoyo: true,
+    ...options
+  });
+}

--- a/src/main.js
+++ b/src/main.js
@@ -1,0 +1,15 @@
+import AppManager from './core/AppManager.js';
+import template from './templates/sampleTemplate.json';
+import registerEffects from './effects/register.js';
+
+registerEffects();
+
+const appManager = new AppManager({
+  width: 800,
+  height: 600,
+  backgroundColor: 0x000000
+});
+
+document.body.appendChild(appManager.view);
+
+appManager.loadTemplate(template);

--- a/src/templates/sampleTemplate.json
+++ b/src/templates/sampleTemplate.json
@@ -1,0 +1,22 @@
+{
+  "layers": [
+    {
+      "type": "text",
+      "text": "Hello PixiJS",
+      "style": { "fill": "#ffffff", "fontSize": 36 },
+      "props": { "x": 100, "y": 100 },
+      "animations": [
+        { "type": "bounce", "params": { "from": 0.5, "to": 1.2, "duration": 1 } }
+      ]
+    },
+    {
+      "type": "sprite",
+      "texture": "https://pixijs.io/examples/examples/assets/bunny.png",
+      "props": { "x": 400, "y": 300, "anchor": { "x": 0.5, "y": 0.5 } },
+      "animations": [
+        { "type": "shake", "params": { "duration": 0.1, "repeat": 10 } },
+        { "type": "fadeInOut", "params": { "duration": 2 } }
+      ]
+    }
+  ]
+}

--- a/src/utils/index.js
+++ b/src/utils/index.js
@@ -1,0 +1,2 @@
+export { default as parseProps } from './parseProps.js';
+export { default as parseAnimations } from './parseAnimations.js';

--- a/src/utils/parseAnimations.js
+++ b/src/utils/parseAnimations.js
@@ -1,0 +1,12 @@
+import { gsap } from 'gsap';
+
+export default function parseAnimations(target, animations = [], effects = {}) {
+  animations.forEach(anim => {
+    const { type, params, options } = anim;
+    if (effects[type]) {
+      effects[type](target, params, options);
+    } else {
+      gsap.to(target, { ...params, ...options });
+    }
+  });
+}

--- a/src/utils/parseProps.js
+++ b/src/utils/parseProps.js
@@ -1,0 +1,9 @@
+export default function parseProps(target, props = {}) {
+  Object.entries(props).forEach(([key, value]) => {
+    if (typeof target[key] === 'object' && target[key] !== null) {
+      Object.assign(target[key], value);
+    } else if (key in target) {
+      target[key] = value;
+    }
+  });
+}

--- a/vite.config.js
+++ b/vite.config.js
@@ -1,0 +1,8 @@
+import { defineConfig } from 'vite';
+
+export default defineConfig({
+  root: 'src',
+  build: {
+    outDir: '../dist'
+  }
+});


### PR DESCRIPTION
## Summary
- set up project structure for PixiJS + GSAP with Vite
- implement core classes (`AppManager`, `SceneManager`, `LayerFactory`, `EffectRegistry`)
- add reusable effects and registration helper
- create sample JSON template for data‑driven scenes
- include utility helpers for parsing props and animations
- update README with usage instructions

## Testing
- `npm install` *(fails: 403 Forbidden due to network restrictions)*
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_b_685505c5bfd8832cb24fe17d94e183e6