### PR TITLE
Fix fadeInOut timeline and preload sprite assets

### DIFF
--- a/src/core/AppManager.js
+++ b/src/core/AppManager.js
@@ -27,7 +27,7 @@ export default class AppManager {
     return this.app.canvas;
   }
 
-  loadTemplate(template) {
-    this.sceneManager.loadScene(template);
+  async loadTemplate(template) {
+    await this.sceneManager.loadScene(template);
   }
 }

--- a/src/core/LayerFactory.js
+++ b/src/core/LayerFactory.js
@@ -2,13 +2,14 @@ import * as PIXI from 'pixi.js';
 import { parseProps } from '../utils/index.js';
 
 export default class LayerFactory {
-  static create(data, app) {
+  static async create(data, app) {
     let layer;
     switch (data.type) {
       case 'text':
         layer = new PIXI.Text(data.text || '', data.style || {});
         break;
       case 'sprite':
+        await PIXI.Assets.load(data.texture);
         layer = PIXI.Sprite.from(data.texture);
         break;
       default:

--- a/src/core/SceneManager.js
+++ b/src/core/SceneManager.js
@@ -13,13 +13,13 @@ export default class SceneManager {
     this.layers = [];
   }
 
-  loadScene(data) {
+  async loadScene(data) {
     this.clear();
-    data.layers.forEach(layerData => {
-      const layer = LayerFactory.create(layerData, this.app);
+    for (const layerData of data.layers) {
+      const layer = await LayerFactory.create(layerData, this.app);
       this.app.stage.addChild(layer);
       parseAnimations(layer, layerData.animations, EffectRegistry.effects);
       this.layers.push(layer);
-    });
+    }
   }
 }

--- a/src/effects/fadeInOut.js
+++ b/src/effects/fadeInOut.js
@@ -2,6 +2,8 @@ import { gsap } from 'gsap';
 
 export default function fadeInOut(target, params = {}, options = {}) {
   const { duration = 1 } = params;
-  gsap.fromTo(target, { alpha: 0 }, { alpha: 1, duration: duration / 2, ...options })
+  const tl = gsap.timeline(options);
+  tl.fromTo(target, { alpha: 0 }, { alpha: 1, duration: duration / 2 })
     .to(target, { alpha: 0, duration: duration / 2 });
+  return tl;
 }

--- a/src/main.js
+++ b/src/main.js
@@ -8,4 +8,4 @@ const appManager = await AppManager.create();
 
 document.body.appendChild(appManager.view);
 
-appManager.loadTemplate(template);
+await appManager.loadTemplate(template);


### PR DESCRIPTION
## Summary
- adjust fadeInOut effect to use a GSAP timeline
- preload sprite textures with `PIXI.Assets` in `LayerFactory`
- make scene loading async to await asset creation

## Testing
- `npm test` *(fails: Missing script)*
- `npm run build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_b_685517b74118832c8fc0a61dfdd4451f