### PR TITLE
Add timeline support

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -10,6 +10,7 @@ src/
   effects/         # reusable animation effects
   templates/       # JSON templates describing scenes
   utils/           # helper functions for property and animation parsing
+  TimelineFactory  # builds GSAP timelines from template scenes
   main.js          # entry file used by Vite
 ```
 

--- a/src/core/AppManager.js
+++ b/src/core/AppManager.js
@@ -1,10 +1,12 @@
 import { Application } from 'pixi.js';
 import SceneManager from './SceneManager.js';
+import TimelineFactory from './TimelineFactory.js';
 
 export default class AppManager {
-  constructor(app, sceneManager) {
+  constructor(app, sceneManager, timelineFactory) {
     this.app = app;
     this.sceneManager = sceneManager;
+    this.timelineFactory = timelineFactory;
   }
 
   static async create(options = {}) {
@@ -18,9 +20,10 @@ export default class AppManager {
       ...options
     });
 
-    const sceneManager = new SceneManager(app); 
-    
-    return new AppManager(app, sceneManager);
+    const sceneManager = new SceneManager(app);
+    const timelineFactory = new TimelineFactory(sceneManager);
+
+    return new AppManager(app, sceneManager, timelineFactory);
   }
   
   get view() {
@@ -29,5 +32,9 @@ export default class AppManager {
 
   async loadTemplate(template) {
     await this.sceneManager.loadScene(template);
+  }
+
+  async loadTimeline(timelineData) {
+    return this.timelineFactory.create(timelineData);
   }
 }

--- a/src/core/LayerFactory.js
+++ b/src/core/LayerFactory.js
@@ -12,6 +12,10 @@ export default class LayerFactory {
         await PIXI.Assets.load(data.texture);
         layer = PIXI.Sprite.from(data.texture);
         break;
+      case 'image':
+        await PIXI.Assets.load(data.src);
+        layer = PIXI.Sprite.from(data.src);
+        break;
       default:
         layer = new PIXI.Container();
     }

--- a/src/core/SceneManager.js
+++ b/src/core/SceneManager.js
@@ -18,7 +18,9 @@ export default class SceneManager {
     for (const layerData of data.layers) {
       const layer = await LayerFactory.create(layerData, this.app);
       this.app.stage.addChild(layer);
-      parseAnimations(layer, layerData.animations, EffectRegistry.effects);
+      if (Array.isArray(layerData.animations) && layerData.animations.length && layerData.animations[0].type) {
+        parseAnimations(layer, layerData.animations, EffectRegistry.effects);
+      }
       this.layers.push(layer);
     }
   }

--- a/src/core/TimelineFactory.js
+++ b/src/core/TimelineFactory.js
@@ -1,0 +1,49 @@
+import { gsap } from 'gsap';
+import { parseProps } from '../utils/index.js';
+
+export default class TimelineFactory {
+  constructor(sceneManager) {
+    this.sceneManager = sceneManager;
+  }
+
+  async create(data) {
+    const master = gsap.timeline();
+    for (const scene of data.scenes) {
+      await this.sceneManager.loadScene(scene);
+      const tl = this._buildSceneTimeline(scene);
+      master.add(tl);
+      master.add(() => this.sceneManager.clear());
+    }
+    return master;
+  }
+
+  _buildSceneTimeline(sceneData) {
+    const tl = gsap.timeline();
+    if (sceneData.transitionIn && sceneData.transitionIn.duration) {
+      tl.from(this.sceneManager.layers, {
+        alpha: 0,
+        duration: sceneData.transitionIn.duration,
+        stagger: 0
+      });
+    }
+
+    sceneData.layers.forEach((layerData, index) => {
+      const layer = this.sceneManager.layers[index];
+      parseProps(layer, layerData.props);
+      (layerData.animations || []).forEach(anim => {
+        tl.to(layer, { ...anim.to, duration: anim.duration, ease: anim.easing }, anim.at);
+      });
+    });
+
+    if (sceneData.transitionOut && sceneData.transitionOut.duration) {
+      tl.to(this.sceneManager.layers, {
+        alpha: 0,
+        duration: sceneData.transitionOut.duration,
+        stagger: 0
+      }, sceneData.duration - sceneData.transitionOut.duration);
+    }
+
+    tl.to({}, { duration: sceneData.duration });
+    return tl;
+  }
+}

--- a/src/main.js
+++ b/src/main.js
@@ -1,5 +1,5 @@
 import AppManager from './core/AppManager.js';
-import template from './templates/sampleTemplate.json';
+import timeline from './templates/timelineTemplate.json';
 import registerEffects from './effects/register.js';
 
 registerEffects();
@@ -8,4 +8,5 @@ const appManager = await AppManager.create();
 
 document.body.appendChild(appManager.view);
 
-await appManager.loadTemplate(template);
+const tl = await appManager.loadTimeline(timeline);
+tl.play();

--- a/src/templates/timelineTemplate.json
+++ b/src/templates/timelineTemplate.json
@@ -1,0 +1,43 @@
+{
+  "scenes": [
+    {
+      "duration": 4,
+      "transitionIn": { "duration": 0.5 },
+      "transitionOut": { "duration": 0.5 },
+      "layers": [
+        {
+          "type": "image",
+          "src": "logo.png",
+          "props": { "x": 200, "y": 100, "alpha": 0 },
+          "animations": [
+            { "at": 0, "to": { "alpha": 1, "scale": 1.2 }, "duration": 1, "easing": "power2.out" }
+          ]
+        },
+        {
+          "type": "text",
+          "text": "Hello World!",
+          "props": { "x": 300, "y": 300, "alpha": 0 },
+          "animations": [
+            { "at": 1, "to": { "alpha": 1 }, "duration": 0.5 },
+            { "at": 3, "to": { "alpha": 0 }, "duration": 0.5 }
+          ]
+        }
+      ]
+    },
+    {
+      "duration": 3,
+      "transitionIn": { "duration": 0.5 },
+      "transitionOut": { "duration": 0.5 },
+      "layers": [
+        {
+          "type": "text",
+          "text": "Scene 2!",
+          "props": { "x": 400, "y": 200, "alpha": 0, "scale": 2 },
+          "animations": [
+            { "at": 0, "to": { "alpha": 1, "scale": 1 }, "duration": 1, "easing": "bounce.out" }
+          ]
+        }
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
## Summary
- add `TimelineFactory` to build GSAP timelines from scene data
- support `image` layers in `LayerFactory`
- update `SceneManager` to only parse effect-style animations when needed
- extend `AppManager` with `loadTimeline`
- provide example `timelineTemplate.json`
- update main entry to play timeline
- document timeline factory in README

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_b_685530731fac832cb9a20c3b305b0ca3