### PR TITLE
Use new PIXI.Text constructor

### DIFF
--- a/src/core/LayerFactory.js
+++ b/src/core/LayerFactory.js
@@ -6,7 +6,7 @@ export default class LayerFactory {
     let layer;
     switch (data.type) {
       case 'text':
-        layer = new PIXI.Text(data.text || '', data.style || {});
+        layer = new PIXI.Text({ text: data.text || '', style: data.style || {} });
         break;
       case 'sprite':
         await PIXI.Assets.load(data.texture);


### PR DESCRIPTION
## Summary
- update text layer creation logic for PixiJS v8

## Testing
- `npm run build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_b_685534b7ef78832c8021fa4737d82dfb