### PR TITLE
Remove empty tween from timeline

### DIFF
--- a/src/core/TimelineFactory.js
+++ b/src/core/TimelineFactory.js
@@ -61,7 +61,7 @@ export default class TimelineFactory {
       }, sceneData.duration - sceneData.transitionOut.duration);
     }
 
-    tl.to({}, { duration: sceneData.duration });
+    tl.add(sceneData.duration);
     return tl;
   }
 }


### PR DESCRIPTION
## Summary
- avoid creating an empty GSAP tween and instead wait using `tl.add`

## Testing
- `npm test`
- *(attempted to run sample timeline but dependencies were missing)*

------
https://chatgpt.com/codex/tasks/task_b_68553c8e13e0832caa449b79ebe62e97