### PR TITLE
Add zoom-in and spin-close effects

### DIFF
--- a/src/effects/index.js
+++ b/src/effects/index.js
@@ -3,11 +3,15 @@ import glitch from './glitch.js';
 import blur from './blur.js';
 import bounce from './bounce.js';
 import fadeInOut from './fadeInOut.js';
+import zoomIn from './zoomIn.js';
+import spinClose from './spinClose.js';
 
 export default {
   shake,
   glitch,
   blur,
   bounce,
-  fadeInOut
+  fadeInOut,
+  zoomIn,
+  spinClose
 };

--- a/src/effects/spinClose.js
+++ b/src/effects/spinClose.js
@@ -1,0 +1,19 @@
+import { gsap } from 'gsap';
+
+export default function spinClose(target, params = {}, options = {}) {
+  const {
+    rotation = 180,
+    to = 0,
+    duration = 0.5,
+    ease = 'power2.in'
+  } = params;
+
+  gsap.to(target, {
+    rotation,
+    scale: to,
+    alpha: 0,
+    duration,
+    ease,
+    ...options
+  });
+}

--- a/src/effects/zoomIn.js
+++ b/src/effects/zoomIn.js
@@ -1,0 +1,18 @@
+import { gsap } from 'gsap';
+
+export default function zoomIn(target, params = {}, options = {}) {
+  const {
+    from = 0,
+    to = 1,
+    alphaFrom = 0,
+    alphaTo = 1,
+    duration = 0.5,
+    ease = 'power2.out'
+  } = params;
+
+  gsap.fromTo(
+    target,
+    { scale: from, alpha: alphaFrom },
+    { scale: to, alpha: alphaTo, duration, ease, ...options }
+  );
+}

--- a/src/templates/sampleTemplate.json
+++ b/src/templates/sampleTemplate.json
@@ -14,8 +14,9 @@
       "texture": "https://pixijs.io/examples/examples/assets/bunny.png",
       "props": { "x": 400, "y": 300, "anchor": { "x": 0.5, "y": 0.5 } },
       "animations": [
+        { "type": "zoomIn", "params": { "from": 0, "to": 1, "duration": 0.5 } },
         { "type": "shake", "params": { "duration": 0.1, "repeat": 10 } },
-        { "type": "fadeInOut", "params": { "duration": 2 } }
+        { "type": "spinClose", "params": { "rotation": 360, "duration": 0.5 }, "options": { "delay": 2 } }
       ]
     }
   ]


### PR DESCRIPTION
## Summary
- add new modular `zoomIn` and `spinClose` effects for common image transitions
- export new effects and use them in sample template

## Testing
- `npm run test`

------
https://chatgpt.com/codex/tasks/task_b_68554d93d680832c8f27121b1add7115