### PR TITLE
Enable effect-based scene animations

### DIFF
--- a/src/core/SceneManager.js
+++ b/src/core/SceneManager.js
@@ -13,12 +13,19 @@ export default class SceneManager {
     this.layers = [];
   }
 
-  async loadScene(data) {
+  async loadScene(data, options = {}) {
+    const { applyAnimations = true } = options;
+
     this.clear();
     for (const layerData of data.layers) {
       const layer = await LayerFactory.create(layerData, this.app);
       this.app.stage.addChild(layer);
-      if (Array.isArray(layerData.animations) && layerData.animations.length && layerData.animations[0].type) {
+      if (
+        applyAnimations &&
+        Array.isArray(layerData.animations) &&
+        layerData.animations.length &&
+        layerData.animations[0].type
+      ) {
         parseAnimations(layer, layerData.animations, EffectRegistry.effects);
       }
       this.layers.push(layer);

--- a/src/core/TimelineFactory.js
+++ b/src/core/TimelineFactory.js
@@ -1,5 +1,6 @@
 import { gsap } from 'gsap';
 import { parseProps } from '../utils/index.js';
+import EffectRegistry from './EffectRegistry.js';
 
 export default class TimelineFactory {
   constructor(sceneManager) {
@@ -12,7 +13,7 @@ export default class TimelineFactory {
     // preload all scene layers but keep them off stage
     const scenes = [];
     for (const scene of data.scenes) {
-      await this.sceneManager.loadScene(scene);
+      await this.sceneManager.loadScene(scene, { applyAnimations: false });
       // Clone the layers for each scene
       scenes.push({ data: scene, layers: [...this.sceneManager.layers] });
       this.sceneManager.clear();
@@ -69,7 +70,19 @@ export default class TimelineFactory {
       if (!layer) return; // Guard if index mismatch
       parseProps(layer, layerData.props);
       (layerData.animations || []).forEach(anim => {
-        tl.to(layer, { ...anim.to, duration: anim.duration, ease: anim.easing }, anim.at);
+        if (anim.type) {
+          const effect = EffectRegistry.effects[anim.type];
+          if (effect) {
+            const tween = effect(layer, anim.params || {}, anim.options || {});
+            if (tween) tl.add(tween, anim.at || 0);
+          }
+        } else {
+          tl.to(
+            layer,
+            { ...anim.to, duration: anim.duration, ease: anim.easing },
+            anim.at
+          );
+        }
       });
     });
 

--- a/src/effects/blur.js
+++ b/src/effects/blur.js
@@ -6,5 +6,11 @@ export default function blur(target, params = {}, options = {}) {
   if (!target.filters) target.filters = [];
   const filter = new BlurFilter(0);
   target.filters.push(filter);
-  gsap.to(filter, { blur: strength, duration, yoyo: true, repeat: 1, ...options });
+  return gsap.to(filter, {
+    blur: strength,
+    duration,
+    yoyo: true,
+    repeat: 1,
+    ...options
+  });
 }

--- a/src/effects/bounce.js
+++ b/src/effects/bounce.js
@@ -2,10 +2,15 @@ import { gsap } from 'gsap';
 
 export default function bounce(target, params = {}, options = {}) {
   const { from = 0.5, to = 1, duration = 1 } = params;
-  gsap.fromTo(target.scale, { x: from, y: from }, {
-    x: to, y: to,
-    ease: 'elastic.out(1, 0.3)',
-    duration,
-    ...options
-  });
+  return gsap.fromTo(
+    target.scale,
+    { x: from, y: from },
+    {
+      x: to,
+      y: to,
+      ease: 'elastic.out(1, 0.3)',
+      duration,
+      ...options
+    }
+  );
 }

--- a/src/effects/glitch.js
+++ b/src/effects/glitch.js
@@ -2,7 +2,7 @@ import { gsap } from 'gsap';
 
 export default function glitch(target, params = {}, options = {}) {
   const { amount = 5, duration = 0.1, repeat = 20 } = params;
-  gsap.to(target, {
+  return gsap.to(target, {
     pixi: { skewX: () => (Math.random() - 0.5) * amount },
     repeat,
     yoyo: true,

--- a/src/effects/shake.js
+++ b/src/effects/shake.js
@@ -2,9 +2,16 @@ import { gsap } from 'gsap';
 
 export default function shake(target, params = {}, options = {}) {
   const { x = 10, y = 10, duration = 0.2, repeat = 5 } = params;
-  gsap.fromTo(target, { x: `-=${x}`, y: `-=${y}` }, {
-    x: `+=${x}`, y: `+=${y}`,
-    duration, repeat, yoyo: true,
-    ...options
-  });
+  return gsap.fromTo(
+    target,
+    { x: `-=${x}`, y: `-=${y}` },
+    {
+      x: `+=${x}`,
+      y: `+=${y}`,
+      duration,
+      repeat,
+      yoyo: true,
+      ...options
+    }
+  );
 }

--- a/src/effects/spinClose.js
+++ b/src/effects/spinClose.js
@@ -8,7 +8,7 @@ export default function spinClose(target, params = {}, options = {}) {
     ease = 'power2.in'
   } = params;
 
-  gsap.to(target, {
+  return gsap.to(target, {
     rotation,
     scale: to,
     alpha: 0,

--- a/src/effects/zoomIn.js
+++ b/src/effects/zoomIn.js
@@ -10,7 +10,7 @@ export default function zoomIn(target, params = {}, options = {}) {
     ease = 'power2.out'
   } = params;
 
-  gsap.fromTo(
+  return gsap.fromTo(
     target,
     { scale: from, alpha: alphaFrom },
     { scale: to, alpha: alphaTo, duration, ease, ...options }

--- a/src/templates/timelineTemplate.json
+++ b/src/templates/timelineTemplate.json
@@ -117,7 +117,9 @@
             "anchor": { "x": 0.5, "y": 0.5 }
           },
           "animations": [
-            { "type": "zoomIn", "params": { "from": 0, "to": 1, "duration": 1 } }
+            { "type": "zoomIn", "params": { "from": 0, "to": 1, "duration": 0.5 } },
+            { "type": "shake", "params": { "duration": 0.1, "repeat": 10 } },
+            { "type": "spinClose", "params": { "rotation": 360, "duration": 0.5 }, "options": { "delay": 2 } }
           ]
         }
       ]


### PR DESCRIPTION
## Summary
- support optional effect animations when loading scenes
- preload scenes without running animations
- register effects in TimelineFactory and add effect-based playback
- return GSAP tweens from effect helpers
- update template to show effect sequence

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_6855e93633a8832c9edc40acc8a8fa48