### PR TITLE
Remove immediateRender usage

### DIFF
--- a/src/core/TimelineFactory.js
+++ b/src/core/TimelineFactory.js
@@ -76,8 +76,8 @@ export default class TimelineFactory {
             const tween = effect(
               layer,
               anim.params || {},
-              { paused: true, immediateRender: false, ...(anim.options || {}) }
-            ); 
+              { paused: true, ...(anim.options || {}) }
+            );
             if (tween) tl.add(tween, anim.at || 0);
           }
         } else {


### PR DESCRIPTION
## Summary
- build scene timelines without forcing `immediateRender: false`

## Testing
- `npm run test`

------
https://chatgpt.com/codex/tasks/task_b_6855f4859ee8832ca3c163fefde52723