### PR TITLE
Add responsive canvas support

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -34,6 +34,17 @@ npm run build
 npm run preview
 ```
 
+### Responsive Stage
+
+`AppManager.create` accepts a `responsive` option that scales the Pixi stage
+to match the browser window while preserving the aspect ratio. Coordinates in
+the JSON templates use the base width and height provided when creating the
+app (by default `1920x1080`) and are automatically scaled on resize.
+
+```javascript
+const appManager = await AppManager.create({ responsive: true });
+```
+
 ## Loading Timelines
 
 `AppManager` can build a GSAP timeline from a JSON file. The example template at `src/templates/timelineTemplate.json` describes two scenes. Load it using `loadTimeline` and play the resulting timeline:

--- a/src/core/AppManager.js
+++ b/src/core/AppManager.js
@@ -3,27 +3,40 @@ import SceneManager from './SceneManager.js';
 import TimelineFactory from './TimelineFactory.js';
 
 export default class AppManager {
-  constructor(app, sceneManager, timelineFactory) {
+  constructor(app, sceneManager, timelineFactory, baseWidth, baseHeight) {
     this.app = app;
     this.sceneManager = sceneManager;
     this.timelineFactory = timelineFactory;
+    this.baseWidth = baseWidth;
+    this.baseHeight = baseHeight;
   }
 
   static async create(options = {}) {
+    const {
+      width = 1920,
+      height = 1080,
+      responsive = false,
+      ...rest
+    } = options;
+
     const app = new Application();
     await app.init({
-      width: 1920,
-      height: 1080,
+      width,
+      height,
       backgroundColor: "#ccc",
       antialias: true,
       preserveDrawingBuffer: true,
-      ...options
+      ...rest
     });
 
     const sceneManager = new SceneManager(app);
     const timelineFactory = new TimelineFactory(sceneManager);
 
-    return new AppManager(app, sceneManager, timelineFactory);
+    const manager = new AppManager(app, sceneManager, timelineFactory, width, height);
+
+    if (responsive) manager.enableResponsive();
+
+    return manager;
   }
   
   get view() {
@@ -36,5 +49,18 @@ export default class AppManager {
 
   async loadTimeline(timelineData) {
     return this.timelineFactory.create(timelineData);
+  }
+
+  enableResponsive() {
+    const resize = () => {
+      const w = window.innerWidth;
+      const h = window.innerHeight;
+      const scale = Math.min(w / this.baseWidth, h / this.baseHeight);
+      this.app.renderer.resize(w, h);
+      this.app.stage.scale.set(scale);
+    };
+
+    window.addEventListener('resize', resize);
+    resize();
   }
 }

--- a/src/main.js
+++ b/src/main.js
@@ -5,7 +5,7 @@ import registerEffects from './effects/register.js';
 
 registerEffects();
 
-const appManager = await AppManager.create();
+const appManager = await AppManager.create({ responsive: true });
 
 document.body.appendChild(appManager.view);
 


### PR DESCRIPTION
## Summary
- allow `AppManager.create` to scale the stage on window resize
- enable responsive mode in the example `main.js`
- document the new feature in `readme.md`

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_685654f25190832caddfeb605bcca2c3