### PR TITLE
Implement percent-based layer positioning

### DIFF
--- a/src/core/AppManager.js
+++ b/src/core/AppManager.js
@@ -28,6 +28,8 @@ export default class AppManager {
       preserveDrawingBuffer: true,
       ...rest
     });
+    app.baseWidth = width;
+    app.baseHeight = height;
 
     const sceneManager = new SceneManager(app);
     const timelineFactory = new TimelineFactory(sceneManager);

--- a/src/core/LayerFactory.js
+++ b/src/core/LayerFactory.js
@@ -1,5 +1,5 @@
 import * as PIXI from 'pixi.js';
-import { parseProps } from '../utils/index.js';
+import { parsePropsResponsive } from '../utils/index.js';
 
 export default class LayerFactory {
   static async create(data, app) {
@@ -23,7 +23,12 @@ export default class LayerFactory {
         layer = new PIXI.Container();
     }
 
-    parseProps(layer, data.props);
+    parsePropsResponsive(
+      layer,
+      data.props,
+      app.baseWidth || app.renderer.width,
+      app.baseHeight || app.renderer.height
+    );
     return layer;
   }
 }

--- a/src/core/TimelineFactory.js
+++ b/src/core/TimelineFactory.js
@@ -1,5 +1,5 @@
 import { gsap } from 'gsap';
-import { parseProps } from '../utils/index.js';
+import { parsePropsResponsive, computeResponsiveProps } from '../utils/index.js';
 import EffectRegistry from './EffectRegistry.js';
 
 // Pastikan ini dijalankan setelah ketiga script di atas dimuat!
@@ -73,7 +73,12 @@ export default class TimelineFactory {
     (sceneData.layers || []).forEach((layerData, index) => {
       const layer = layers[index];
       if (!layer) return;
-      parseProps(layer, layerData.props);
+      parsePropsResponsive(
+        layer,
+        layerData.props,
+        this.sceneManager.app.baseWidth || this.sceneManager.app.renderer.width,
+        this.sceneManager.app.baseHeight || this.sceneManager.app.renderer.height
+      );
 
       (layerData.animations || []).forEach(anim => {
         // Penentuan waktu mulai animasi: gunakan anim.at jika ada, jika tidak default 0 (paralel)
@@ -98,9 +103,14 @@ export default class TimelineFactory {
             if (tween) tl.add(tween, at);
           }
         } else {
+          const toProps = computeResponsiveProps(
+            anim.to || {},
+            this.sceneManager.app.baseWidth || this.sceneManager.app.renderer.width,
+            this.sceneManager.app.baseHeight || this.sceneManager.app.renderer.height
+          );
           tl.to(
             layer,
-            { ...anim.to, duration: effectDuration, ease: anim.easing },
+            { ...toProps, duration: effectDuration, ease: anim.easing },
             at
           );
         }

--- a/src/utils/index.js
+++ b/src/utils/index.js
@@ -1,2 +1,3 @@
 export { default as parseProps } from './parseProps.js';
 export { default as parseAnimations } from './parseAnimations.js';
+export { parsePropsResponsive, computeResponsiveProps } from './parsePropsResponsive.js';

--- a/src/utils/parsePropsResponsive.js
+++ b/src/utils/parsePropsResponsive.js
@@ -1,7 +1,5 @@
-export function parsePropsResponsive(layer, props, stageWidth, stageHeight) {
-  // Simpan originalProps untuk re-responsive saat resize
-  if (!layer.originalProps) layer.originalProps = JSON.parse(JSON.stringify(props));
-
+export function computeResponsiveProps(props = {}, stageWidth, stageHeight) {
+  const out = {};
   for (const key in props) {
     let val = props[key];
 
@@ -12,15 +10,41 @@ export function parsePropsResponsive(layer, props, stageWidth, stageHeight) {
       if (key === "scale") val = num;
     }
 
+    if (key === "anchor" && typeof val === "object") {
+      out[key] = {
+        x:
+          val.x && typeof val.x === "string" && val.x.endsWith("%")
+            ? parseFloat(val.x) / 100
+            : val.x,
+        y:
+          val.y && typeof val.y === "string" && val.y.endsWith("%")
+            ? parseFloat(val.y) / 100
+            : val.y
+      };
+      continue;
+    }
+
+    out[key] = val;
+  }
+  return out;
+}
+
+export function parsePropsResponsive(layer, props = {}, stageWidth, stageHeight) {
+  if (!layer) return;
+  // Simpan originalProps untuk re-responsive saat resize
+  if (!layer.originalProps) layer.originalProps = JSON.parse(JSON.stringify(props));
+
+  const converted = computeResponsiveProps(props, stageWidth, stageHeight);
+
+  for (const key in converted) {
+    const val = converted[key];
+
     if (key === "scale" && layer.scale && layer.scale.set) {
       layer.scale.set(val, val);
       continue;
     }
     if (key === "anchor" && typeof val === "object" && layer.anchor && layer.anchor.set) {
-      layer.anchor.set(
-        val.x && typeof val.x === "string" && val.x.endsWith("%") ? parseFloat(val.x) / 100 : (val.x || 0),
-        val.y && typeof val.y === "string" && val.y.endsWith("%") ? parseFloat(val.y) / 100 : (val.y || 0)
-      );
+      layer.anchor.set(val.x || 0, val.y || 0);
       continue;
     }
     if (layer[key] !== undefined) layer[key] = val;


### PR DESCRIPTION
## Summary
- add `computeResponsiveProps` helper and update `parsePropsResponsive`
- export new helpers
- apply responsive parsing in LayerFactory and TimelineFactory
- store `baseWidth` and `baseHeight` on the Pixi application

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_68565c03ca18832c8db7382a4591047d